### PR TITLE
feat(deployer-aws-lambda): add option to configure CloudFront invalidation routes

### DIFF
--- a/packages/core/src/constants.ts
+++ b/packages/core/src/constants.ts
@@ -26,6 +26,7 @@ const AWS_LAMBDA_CONFIG = {
   region: '',
   cf_distribution_id: '',
   lambda_arn: '',
+  routes_for_invalidation: ['/'],
 }
 const AWS_S3_CONFIG = {
   access_key: '',

--- a/packages/deployer-aws-lambda/src/aws.ts
+++ b/packages/deployer-aws-lambda/src/aws.ts
@@ -95,7 +95,6 @@ export const updateCloudFront = async (
   log.tick(`Done.`)
   log(`Got response status: 💛${update_response.Distribution?.Status}💛
     🖤(CloudFront can take a few minutes to update)🖤`)
-  // todo: make this a config option
   const num_invalidations = routes_for_invalidation.length
   log(
     `Invalidating ${num_invalidations} route${

--- a/packages/deployer-aws-lambda/src/aws.ts
+++ b/packages/deployer-aws-lambda/src/aws.ts
@@ -36,7 +36,8 @@ export const updateCloudFront = async (
   lambda_arn: string,
   cf_distribution_id: string,
   region: string,
-  version: string
+  version: string,
+  routes_for_invalidation: string[] = ['/']
 ) => {
   const cloudfront = new aws.CloudFront({
     accessKeyId,
@@ -95,7 +96,6 @@ export const updateCloudFront = async (
   log(`Got response status: 💛${update_response.Distribution?.Status}💛
     🖤(CloudFront can take a few minutes to update)🖤`)
   // todo: make this a config option
-  const routes_for_invalidation = ['/']
   const num_invalidations = routes_for_invalidation.length
   log(
     `Invalidating ${num_invalidations} route${
@@ -115,8 +115,8 @@ export const updateCloudFront = async (
         InvalidationBatch: {
           CallerReference: '' + new Date(),
           Paths: {
-            Quantity: 1,
-            Items: ['/'],
+            Quantity: num_invalidations,
+            Items: routes_for_invalidation,
           },
         },
       })

--- a/packages/deployer-aws-lambda/src/deploy.ts
+++ b/packages/deployer-aws-lambda/src/deploy.ts
@@ -16,7 +16,14 @@ export const deployServer: FabServerDeployer<ConfigTypes.AwsLambda> = async (
   const package_path = path.join(working_dir, 'aws-lambda.zip')
   log(`Starting 💛server💛 deploy...`)
 
-  const { access_key, secret_key, region, cf_distribution_id, lambda_arn } = config
+  const {
+    access_key,
+    secret_key,
+    region,
+    cf_distribution_id,
+    lambda_arn,
+    routes_for_invalidation,
+  } = config
 
   const required_keys: Array<keyof ConfigTypes.AwsLambda> = [
     'region',
@@ -49,7 +56,8 @@ export const deployServer: FabServerDeployer<ConfigTypes.AwsLambda> = async (
     lambda_arn,
     cf_distribution_id,
     region,
-    version!
+    version!,
+    routes_for_invalidation
   )
   log.time((d) => `Deployed in ${d}.`)
   return url

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,47 +184,6 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
-"@fab/cli@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@fab/cli/-/cli-1.0.0-rc.7.tgz#adcc481ba38c6eb615172f77b95f7fcc17ac0f50"
-  integrity sha512-9BHl5ahxE1ntZXQKtLO0Nlu5iyrJyGQrTFIXHGK1G4eFvdvMJNNP/gwgfmtP9FG9IeXEgthZWsm2RDQ6TrYA4Q==
-  dependencies:
-    "@fab/core" "1.0.0-rc.7"
-    "@oclif/command" "^1"
-    "@oclif/config" "^1"
-    "@oclif/errors" "^1"
-    "@oclif/plugin-help" "^2"
-    "@types/fs-extra" "^8.0.1"
-    "@types/jju" "^1.4.1"
-    "@types/node" "^10"
-    "@types/prettier" "^1.19.0"
-    "@types/semver" "^6.2.0"
-    chalk "^3.0.0"
-    chokidar "^3.4.0"
-    cli-ux "^5.4.5"
-    dotenv "^8.2.0"
-    execa "^4.0.0"
-    fs-extra "^8.1.0"
-    jju "^1.4.0"
-    json-keys-sort "^2.0.0"
-    pkg-up "^3.1.0"
-    prettier "^1.19.1"
-    pretty-bytes "^5.3.0"
-    regex-parser "^2.2.10"
-    resolve "^1.17.0"
-    semver "^7.1.1"
-    shelljs "^0.8.3"
-    typescript "^3.7.5"
-
-"@fab/core@1.0.0-rc.7":
-  version "1.0.0-rc.7"
-  resolved "https://registry.yarnpkg.com/@fab/core/-/core-1.0.0-rc.7.tgz#376eec46bf7e34c0284048f65a6c7533c9e599ff"
-  integrity sha512-tfUeUwiT2yqxI2VYzq34ODmrG68eirf+wJ1uYzGhiKEg26l+YDv9VOUv/RIkNqdRHdsqi3NjFDMqxO/jJIV5JA==
-  dependencies:
-    "@types/node" "^12.12.14"
-    mime-types "^2.1.25"
-    path-to-regexp "^6.1.0"
-
 "@fly/v8env@^0.54.0":
   version "0.54.0"
   resolved "https://registry.yarnpkg.com/@fly/v8env/-/v8env-0.54.0.tgz#9e17795f5f2d3df71e3ff9efb970d70778b2dac4"

--- a/yarn.lock
+++ b/yarn.lock
@@ -184,6 +184,47 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fab/cli@1.0.0-rc.7":
+  version "1.0.0-rc.7"
+  resolved "https://registry.yarnpkg.com/@fab/cli/-/cli-1.0.0-rc.7.tgz#adcc481ba38c6eb615172f77b95f7fcc17ac0f50"
+  integrity sha512-9BHl5ahxE1ntZXQKtLO0Nlu5iyrJyGQrTFIXHGK1G4eFvdvMJNNP/gwgfmtP9FG9IeXEgthZWsm2RDQ6TrYA4Q==
+  dependencies:
+    "@fab/core" "1.0.0-rc.7"
+    "@oclif/command" "^1"
+    "@oclif/config" "^1"
+    "@oclif/errors" "^1"
+    "@oclif/plugin-help" "^2"
+    "@types/fs-extra" "^8.0.1"
+    "@types/jju" "^1.4.1"
+    "@types/node" "^10"
+    "@types/prettier" "^1.19.0"
+    "@types/semver" "^6.2.0"
+    chalk "^3.0.0"
+    chokidar "^3.4.0"
+    cli-ux "^5.4.5"
+    dotenv "^8.2.0"
+    execa "^4.0.0"
+    fs-extra "^8.1.0"
+    jju "^1.4.0"
+    json-keys-sort "^2.0.0"
+    pkg-up "^3.1.0"
+    prettier "^1.19.1"
+    pretty-bytes "^5.3.0"
+    regex-parser "^2.2.10"
+    resolve "^1.17.0"
+    semver "^7.1.1"
+    shelljs "^0.8.3"
+    typescript "^3.7.5"
+
+"@fab/core@1.0.0-rc.7":
+  version "1.0.0-rc.7"
+  resolved "https://registry.yarnpkg.com/@fab/core/-/core-1.0.0-rc.7.tgz#376eec46bf7e34c0284048f65a6c7533c9e599ff"
+  integrity sha512-tfUeUwiT2yqxI2VYzq34ODmrG68eirf+wJ1uYzGhiKEg26l+YDv9VOUv/RIkNqdRHdsqi3NjFDMqxO/jJIV5JA==
+  dependencies:
+    "@types/node" "^12.12.14"
+    mime-types "^2.1.25"
+    path-to-regexp "^6.1.0"
+
 "@fly/v8env@^0.54.0":
   version "0.54.0"
   resolved "https://registry.yarnpkg.com/@fly/v8env/-/v8env-0.54.0.tgz#9e17795f5f2d3df71e3ff9efb970d70778b2dac4"


### PR DESCRIPTION
Adds optional `routes_for_invalidation` to the fab config which will automatically invalidate the specified routes. Defaults to the old value `['/']`.